### PR TITLE
🚑  Attempt to fix squished image bug

### DIFF
--- a/src/components/GridGenerator.js
+++ b/src/components/GridGenerator.js
@@ -20,9 +20,7 @@ const GridGenerator = ({ jsonData, setHoverStatus, currentMarkdown }) => {
     };
   
     const renderItems = (items) => {
-      var mdCheck = false;
-      if(currentMarkdown.includes("../department/Extras/Classes"))
-        mdCheck = true;
+      var mdCheck = currentMarkdown.includes("../department/Extras/Classes");
       return items.map((item, index) => (
         <div className="course-circle" key={index} onClick={() => {openModal(item.markdown)}} onMouseEnter={() => {setHoverStatus(true)}} onMouseLeave={() => {setHoverStatus(false)}}>
           { mdCheck ?  

--- a/src/components/ImageComponent.js
+++ b/src/components/ImageComponent.js
@@ -1,12 +1,14 @@
 import React, { useState, useEffect, useCallback } from 'react';
 
-const ImageComponent = ({ imageUrl, placeholderUrl, alt }) => {
+const ImageComponent = ({ imageUrl, placeholderUrl, alt, currentMarkdown }) => {
   const [isValid, setIsValid] = useState(false);
 
   // Define checkImage as a useCallback to memoize it
   const checkImage = useCallback(async () => {
-    if(imageUrl === "")
-      return;
+    if(imageUrl === "") {
+    setIsValid(false); 
+    return;
+    }
     try {
       const response = await fetch(imageUrl);
       if (response.ok) {


### PR DESCRIPTION
After experimenting with the inconsistency, my conclusion was that the bug happens after any class page is loaded, given that the page for 2023 was loaded first. That is, if the first page loaded is that for 2022, it won't happen to any class page until after 2023 is visited. That is why refreshing the page at any non-2023 class solved it.

Further investigation suggested that such classes have an empty string for the image because this is what `<img src={item.image.length > 0? item.image : https://api.dicebear.com/7.x/thumbs/svg?...} alt={item.name} />}` has previously assumed to generate a thumb and that `ImageComponent`'s `checkImage` function does not change the `isValid` when faced with an empty string. This may explain why after 2023 is visited the website keeps it `true` and attempts to use an empty string for the image as in `src={isValid ? imageUrl : placeholderUrl}`.